### PR TITLE
Accumulate stdout and stderr from ssh exec into stringio

### DIFF
--- a/test/test_ssh_connection.rb
+++ b/test/test_ssh_connection.rb
@@ -1,11 +1,13 @@
 require 'egon/undercloud/ssh-connection'
+require 'stringio'
 
 describe "SSHConnection" do
 
   it "should timeout if host unreachable" do
-    connection = SSHConnection.new("194.0.0.0", "mock", "mock")
-    message = connection.execute("ls")
-    expect(message.to_s).to eq("execution expired")
+    connection = Egon::Undercloud::SSHConnection.new("194.0.0.0", "mock", "mock")
+    io = StringIO.new
+    message = connection.execute("ls", io)
+    expect(io.string.strip!).to eq("execution expired")
   end
 
 end


### PR DESCRIPTION
This will allow one to read the execution output and do additional
processing if desired.

For example, you can read the undercloud password, by passing
in a stringio and using "hiera admin password" as the command.
