### PR TITLE
Undercloud port checks

### DIFF
--- a/bin/undercloud-install-instack-virt.rb
+++ b/bin/undercloud-install-instack-virt.rb
@@ -12,3 +12,4 @@ installer.install(Egon::Undercloud::Commands.OSP7_instack_virt)
 while !installer.completed?
   sleep 1
 end  
+installer.check_ports

--- a/bin/undercloud-install-satellite.rb
+++ b/bin/undercloud-install-satellite.rb
@@ -18,3 +18,4 @@ installer.install(Egon::Undercloud::Commands.OSP7_satellite(SATELLITE_URL, SATEL
 while !installer.completed?
   sleep 1
 end  
+installer.check_ports

--- a/bin/undercloud-install-vanilla-rhel.rb
+++ b/bin/undercloud-install-vanilla-rhel.rb
@@ -16,3 +16,4 @@ installer.install(Egon::Undercloud::Commands.OSP7_vanilla_rhel(RHSM_USER, RHSM_P
 while !installer.completed?
   sleep 1
 end  
+installer.check_ports

--- a/egon.gemspec
+++ b/egon.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog", "~> 1.29.0"
   s.add_development_dependency "net-ssh", "~> 2.9.2"
   s.add_development_dependency "rspec", "~> 3.2.0"
+  s.add_development_dependency "curb", "~> 0.8.8"
 end

--- a/lib/egon/undercloud/installer.rb
+++ b/lib/egon/undercloud/installer.rb
@@ -38,6 +38,16 @@ module Egon
           @connection.execute(commands)
         }
       end
+
+      def check_ports
+        # closed ports 5385, 36357
+        ports = [8774, 9292, 8777, 9696, 8004, 5000, 8585, 5672]
+        ports.each do |p|
+          if !@connection.port_open?(p)
+            set_failure(true)
+          end
+        end
+      end
     end
   end
 end

--- a/test/test_ssh_connection.rb
+++ b/test/test_ssh_connection.rb
@@ -10,4 +10,8 @@ describe "SSHConnection" do
     expect(io.string.strip!).to eq("execution expired")
   end
 
+  it "check port is open" do
+    connection = Egon::Undercloud::SSHConnection.new("127.0.0.1", "stack", "test")
+    connection.port_open?(1111).should eq false
+    end
 end

--- a/test/test_undercloud.rb
+++ b/test/test_undercloud.rb
@@ -40,6 +40,11 @@ describe "undercloud installer" do
   it "connection should timeout and installer indicate failure" do
     run_and_assert_installer(@installer, true)
   end
+
+  it "check ports should fail on mock connection" do
+    @installer.check_ports
+    expect(@installer.failure?).to be true
+  end
   
 end
   


### PR DESCRIPTION
Add function to check undercloud services' ports. An open port
indicates a service started up correctly.
