### PR TITLE
Switching rabbit port check to 15672

### DIFF
--- a/lib/egon/undercloud/installer.rb
+++ b/lib/egon/undercloud/installer.rb
@@ -41,7 +41,7 @@ module Egon
 
       def check_ports
         # closed ports 5385, 36357
-        ports = [8774, 9292, 8777, 9696, 8004, 5000, 8585, 5672]
+        ports = [8774, 9292, 8777, 9696, 8004, 5000, 8585, 15672]
         ports.each do |p|
           if !@connection.port_open?(p)
             set_failure(true)


### PR DESCRIPTION
Port 5672 is the AMQP port and checks against it using HTTP is
toublesome, returns EOF error. Port check is changed to 15672, the
management console. This would also indicate that rabbit is up.
