### PR TITLE
More consumable logging from undercloud installer and port checks

### DIFF
--- a/lib/egon/undercloud/installer.rb
+++ b/lib/egon/undercloud/installer.rb
@@ -27,7 +27,7 @@ module Egon
         @failure = bool
       end
     
-      def install(commands)
+      def install(commands, stringio=nil)
         @started = true
         @completed = false
              
@@ -35,15 +35,15 @@ module Egon
         @connection.on_failure(lambda { set_failure(true) })
     
         Thread.new {
-          @connection.execute(commands)
+          @connection.execute(commands, stringio)
         }
       end
 
-      def check_ports
+      def check_ports(stringio=nil)
         # closed ports 5385, 36357
         ports = [8774, 9292, 8777, 9696, 8004, 5000, 8585, 15672]
         ports.each do |p|
-          if !@connection.port_open?(p)
+          if !@connection.port_open?(p, stringio)
             set_failure(true)
           end
         end

--- a/test/test_undercloud.rb
+++ b/test/test_undercloud.rb
@@ -45,6 +45,18 @@ describe "undercloud installer" do
     @installer.check_ports
     expect(@installer.failure?).to be true
   end
-  
+
+  it "consume stdout and stderr from commands" do
+    io = StringIO.new
+    @installer.install("time", io)
+    while !@installer.completed?
+      sleep 1
+    end
+    expect(io.string).to include("execution expired")
+
+    io = StringIO.new
+    @installer.check_ports(io)
+    expect(io.string).to include("Testing")
+  end
 end
   


### PR DESCRIPTION
Allows you to pass in a stringio to accumulate stdout, stderr, and
any additional logging from execution of commands or from port
checks.
