### PR TITLE
Don't try to create a flavor from nil hardware if introspection failed

### DIFF
--- a/lib/egon/overcloud/undercloud_handle/node.rb
+++ b/lib/egon/overcloud/undercloud_handle/node.rb
@@ -105,8 +105,12 @@ module Overcloud
                          'X-Auth-Token' => auth_token},
             :method  => 'GET'
           })
-      finished = Fog::JSON.decode(response.body)['finished']
+      body = Fog::JSON.decode(response.body)
+      finished = body['finished']
       if finished
+        if body['error']
+          raise body['error']
+        end
         create_flavor_from_node(get_node(node_uuid))
       end
       finished


### PR DESCRIPTION
Currently if node introspection fails we try to create a flavor from nil hardware info, which fails with a "can't append nil and String" error. This update checks to see if there are errors in the introspection and throws them up the stack if there are.
