### PR TITLE
make it possible to delete node with nil power status

### DIFF
--- a/lib/egon/overcloud/undercloud_handle/node.rb
+++ b/lib/egon/overcloud/undercloud_handle/node.rb
@@ -87,7 +87,7 @@ module Overcloud
     def delete_node(node_id)
       begin
         node = get_node(node_id)
-        if node.power_state != 'power off' && node.provision_state != 'active'
+        if node.power_state == 'power on' && node.provision_state != 'active'
           node.set_power_state('power off')
           retries = 15
           while retries > 0 && node.power_state != 'power off' do


### PR DESCRIPTION
If a node is created with bad credentials the power status cannot be verified and it returns nil.

It's apparently alright to delete a node if the power state is nil as well as the director allows for this to be done.
