### PR TITLE
Remove flavor defaults for OSP8 undercloud

### DIFF
--- a/lib/egon/undercloud/commands.rb
+++ b/lib/egon/undercloud/commands.rb
@@ -312,10 +312,6 @@ module Egon
         echo '  SwiftStorageImage: overcloud-full' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
         echo '  controllerImage: overcloud-full' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
         echo '  NovaImage: overcloud-full' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
-        echo '  OvercloudBlockStorageFlavor: baremetal' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
-        echo '  OvercloudControlFlavor: baremetal' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
-        echo '  OvercloudComputeFlavor: baremetal' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
-        echo '  OvercloudSwiftStorageFlavor: baremetal' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
         echo '  CinderPassword: Ma3kfBHqB8FDb2hgJa3sPUAzh' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
         echo '  GlancePassword: EBNnAsWxuzAHfqG8trjjMDsCu' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml
         echo '  SwiftPassword: KfqyTxGtQ9y7P6yCK2m7n2xMz' >> openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml


### PR DESCRIPTION
Defaulting a flavor in such a way prevents it from being changed
whatsoever.
