### PR TITLE
Add delete stack method

### DIFF
--- a/lib/egon/overcloud/undercloud_handle/deployment.rb
+++ b/lib/egon/overcloud/undercloud_handle/deployment.rb
@@ -160,6 +160,10 @@ module Overcloud
       list_stacks.find{|s| s.stack_name == stack_name}
     end
 
+    def delete_stack(overcloud)
+      service('Orchestration').delete_stack(overcloud)
+    end
+
     private
     
     def base_tripleo_api_url


### PR DESCRIPTION
We'd like to allow a stack to be deleted if detected on a subsequent QCI deployment run.
