### PR TITLE
use version template to keep rpm and gem in sync

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,7 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+
+[version_template]
+template_file = ./version.rb.tmpl
+destination_file = ./lib/egon/version.rb

--- a/version.rb.tmpl
+++ b/version.rb.tmpl
@@ -1,0 +1,3 @@
+module Egon
+  VERSION = "$version"
+end


### PR DESCRIPTION
This template will allow us to use tito's VersionTagger which will bump the version on the spec file as well as the version.rb using the given template. 
