### PR TITLE
only pickup the necessary files.

### DIFF
--- a/egon.gemspec
+++ b/egon.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.date          = Date.today.to_s
   s.license       = 'GPL-3.0+'
 
-  s.files         = Dir['**/*']
+  s.files         = Dir['lib/**/*'] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files    = Dir['{test,spec,features}/**/*']
   s.executables   = Dir['bin/*'].map{ |f| File.basename(f) }
 


### PR DESCRIPTION
This change prevents randomly picking up files placed in the directory that are
not intended to be part of the gemfile
