### PR TITLE
1344457 - restart swift when service is inactive

### DIFF
--- a/lib/egon/undercloud/commands.rb
+++ b/lib/egon/undercloud/commands.rb
@@ -311,7 +311,7 @@ module Egon
 
       # Temporarily deal with BZ#1319795
       retry_count=0
-      while ! systemctl is-active openstack-swift-* >/dev/null && (( retry_count < retries )); do
+      while ! systemctl is-active openstack-swift-* --all >/dev/null && (( retry_count < retries )); do
         echo \"Swift services not started, retrying.\"
         let retry_count+=1; sudo openstack-service restart swift; sleep 60;
       done


### PR DESCRIPTION
inactive services were being omitted from the results of

``` bash
systemctl is-active openstack-swift-*
```

and the exit code was always 0

adding --all results in an appropriate exit code triggering the restart
